### PR TITLE
Feature/allow users param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.bak
+*.zip
+*.log
+node_modules

--- a/sintacs-mwai-frontend-chatbot-settings.php
+++ b/sintacs-mwai-frontend-chatbot-settings.php
@@ -251,13 +251,21 @@ class SintacsMwaiFrontendChatbotSettings {
 
 	public function form_shortcode( $atts ) {
 		$atts = shortcode_atts( array(
-			'chatbot_id' => ''
+			'chatbot_id' => '',
+			'allow_users' => '',
 		),$atts,'ai_engine_extension_form' );
 
 		$chatbot_id = sanitize_text_field( $atts['chatbot_id'] );
 
 		if ( ! $this->current_user_has_access() ) {
 			return 'You are not allowed to access this feature.';
+		}
+
+		if ( ! empty( $atts['allow_users'] ) ) {
+			$allow_users = preg_split( '/\s*[,;\s]\s*/', sanitize_text_field( $atts['allow_users'] ) );
+			if ( ! is_user_logged_in() || ! in_array( wp_get_current_user()->user_email, $allow_users ) ) {
+				return 'You are not allowed to access this feature.';
+			}
 		}
 
 		if ( ! $this->is_ai_engine_pro_active() ) {


### PR DESCRIPTION
This feature enables a new shortcode attribute "allow_users". If the attribute is defined, the shortcode will only be visible if the logged in user email matches one of the emails defined in the parameter value. The attribute accepts a list of comma-separated user_emails corresponding to the users allowed to view the shortcode.